### PR TITLE
feat(workflows): explicit cargo readme - without Makefile

### DIFF
--- a/lib/.cargo-husky/hooks/pre-commit
+++ b/lib/.cargo-husky/hooks/pre-commit
@@ -14,5 +14,6 @@ echo "$FILES" | xargs git add
 #echo '+cargo clippy -- -D warnings'
 #cargo clippy -- -D warnings
 
-make readme
+echo "+cargo readme > README.md"
+cargo readme > README.md
 git add README.md


### PR DESCRIPTION
Have the hook use `cargo readme` directly.  Projects with their own `Makefile`s don't need that requirement sneaking up on them.